### PR TITLE
Limit Pro Mode to beta roles and add settings dialog

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,15 +12,10 @@
   <div class="topbar">
     <div class="brand">HyperTimer <span class="note" style="margin-left:.4rem;">v6.2.1</span></div><div class="spacer"></div>
     <div class="controls">
-      <div id="accountControls">
-        <button class="btn" id="loginBtn">Log In</button>
-        <button class="btn primary" id="signupBtn">Sign Up</button>
-      </div>
-      <div id="userSession" class="invisible" style="display:flex; gap:.5rem; align-items:center;">
-        <span id="userEmailDisplay" class="note"></span>
-        <button class="btn" id="syncBtn">Sync</button>
-        <button class="btn" id="logoutBtn">Log Out</button>
-      </div>
+      <button class="btn icon" id="settingsBtn" aria-haspopup="dialog" aria-expanded="false">
+        <span class="icon" aria-hidden="true">⚙</span>
+        <span class="label">Settings</span>
+      </button>
       <button class="btn" id="exportBtn">Export</button>
       <label class="btn">Import <input id="importInput" type="file" accept="application/json" style="display:none;"></label>
       <button class="btn" id="tplBtn">Templates ▾</button>
@@ -69,6 +64,7 @@
             <option value="color">Color</option>
             <option value="pro">Pro Mode (Split)</option>
           </select>
+          <div class="note invisible" id="proAccessNotice">Pro Mode requires a Beta Tester, Special Access, or Owner role.</div>
         </div>
       </div>
       <div id="durationFields" class="field-row">
@@ -196,6 +192,35 @@
           <button class="btn" value="cancel">Cancel</button>
           <button class="btn primary" id="saveBtn" type="button">Save</button>
         </div>
+      </div>
+    </div>
+  </form>
+</dialog>
+
+<dialog id="settingsDialog">
+  <form method="dialog" novalidate>
+    <div class="dialog-header">
+      <div class="title">Settings</div>
+      <button class="btn" value="cancel" style="line-height:1;">✕</button>
+    </div>
+    <div class="dialog-body settings-body">
+      <div id="settingsSignedOut" class="settings-section">
+        <div class="note">Sign in to sync timers and unlock experimental features.</div>
+        <div class="settings-actions">
+          <button class="btn" type="button" id="settingsLoginBtn">Log In</button>
+          <button class="btn primary" type="button" id="settingsSignupBtn">Sign Up</button>
+        </div>
+      </div>
+      <div id="settingsSignedIn" class="settings-section invisible">
+        <div class="settings-summary">
+          <div class="note">Signed in as</div>
+          <div id="settingsUserEmail" class="settings-value"></div>
+        </div>
+        <div class="settings-actions">
+          <button class="btn" type="button" id="settingsSyncBtn">Sync Now</button>
+          <button class="btn" type="button" id="settingsLogoutBtn">Log Out</button>
+        </div>
+        <div class="settings-role invisible" id="settingsRoleDisplay"></div>
       </div>
     </div>
   </form>

--- a/script.js
+++ b/script.js
@@ -39,13 +39,17 @@
   const tplBtn = $("#tplBtn");
   const pauseAllBtn = $("#pauseAllBtn");
 
-  const accountControls = $("#accountControls");
-  const userSession = $("#userSession");
-  const loginBtn = $("#loginBtn");
-  const signupBtn = $("#signupBtn");
-  const logoutBtn = $("#logoutBtn");
-  const syncBtn = $("#syncBtn");
-  const userEmailDisplay = $("#userEmailDisplay");
+  const settingsBtn = $("#settingsBtn");
+  const settingsDialog = $("#settingsDialog");
+  const settingsSignedOut = $("#settingsSignedOut");
+  const settingsSignedIn = $("#settingsSignedIn");
+  const settingsLoginBtn = $("#settingsLoginBtn");
+  const settingsSignupBtn = $("#settingsSignupBtn");
+  const settingsLogoutBtn = $("#settingsLogoutBtn");
+  const settingsSyncBtn = $("#settingsSyncBtn");
+  const settingsUserEmail = $("#settingsUserEmail");
+  const settingsRoleDisplay = $("#settingsRoleDisplay");
+  const proAccessNotice = $("#proAccessNotice");
   const authDialog = $("#authDialog");
 
   const f = {
@@ -63,6 +67,27 @@
   };
   const customFormatRow = $("#customFormatRow");
 
+  let lastStyleSelection = f.style ? f.style.value : "bar";
+  if (f.style) {
+    f.style.addEventListener("focus", () => {
+      lastStyleSelection = f.style.value;
+    });
+    f.style.addEventListener("change", () => {
+      if (f.style.value === "pro" && !userCanUseProMode()) {
+        const fallback = lastStyleSelection === "pro" ? "bar" : (lastStyleSelection || "bar");
+        f.style.value = fallback;
+        lastStyleSelection = f.style.value;
+        toggleProAccessNotice(true);
+        updateStyleUI();
+        return;
+      }
+      lastStyleSelection = f.style.value;
+      toggleProAccessNotice(false);
+      updateStyleUI();
+    });
+  }
+  toggleProAccessNotice(false);
+
   let timers = [];
   let templates = [];
   let editId = null;
@@ -77,6 +102,30 @@
     letters: "Letters",
     color: "Color"
   };
+  const ROLE_STANDARD = "Standard";
+  const PRO_MODE_ROLES = new Set(["beta tester", "special access", "owner"]);
+
+  function normalizeRole(role) {
+    if (typeof role === "string") {
+      const trimmed = role.trim();
+      if (trimmed) return trimmed;
+    }
+    return ROLE_STANDARD;
+  }
+
+  function getCurrentRole() {
+    return currentUser?.role ? normalizeRole(currentUser.role) : ROLE_STANDARD;
+  }
+
+  function userCanUseProMode() {
+    const role = getCurrentRole().toLowerCase();
+    return PRO_MODE_ROLES.has(role);
+  }
+
+  function toggleProAccessNotice(show) {
+    if (!proAccessNotice) return;
+    proAccessNotice.classList.toggle("invisible", !show);
+  }
 
   async function updateAndSaveTimers(newTimersArray = null) {
     if (newTimersArray) {
@@ -97,6 +146,10 @@
       const userRaw = localStorage.getItem(KEY_USER);
       if (userRaw) {
         currentUser = JSON.parse(userRaw);
+        if (currentUser) {
+          currentUser.role = normalizeRole(currentUser.role);
+          localStorage.setItem(KEY_USER, JSON.stringify(currentUser));
+        }
         updateUIForLoginState();
       }
       const raw = localStorage.getItem(KEY_TIMERS);
@@ -476,6 +529,10 @@
     return `${tpl.style} • ${tpl.units} • ${Math.random().toString(36).slice(2,6)}`;
   }
   function saveTemplateFromTimer(t){
+    if (t.style === "pro" && !userCanUseProMode()) {
+      alert("Pro Mode templates require Beta Tester or higher accounts.");
+      return;
+    }
     if (t.style === "pro") ensureProSplitState(t);
     const tpl = { id:uid("tpl_"), style:t.style, color:t.color, color2:t.color2, units:t.units, format:t.format,
       ring_thickness:t.ring_thickness, ease:t.ease, tick:t.tick, ms:t.ms, dotsCount:t.dotsCount, mb_bars:t.mb_bars, mb_ticks:t.mb_ticks, letters_n:t.letters_n,
@@ -641,6 +698,16 @@
     f.units.value=draft.units||"auto"; f.format.value=draft.format||"{HH}:{mm}:{ss}";
     f.ring_thickness.value=draft.ring_thickness??10; f.ease.value=draft.ease||"linear"; f.tick.value=draft.tick??100; f.ms.value=draft.ms||"off";
     f.mb_bars.value = draft.mb_bars ?? ""; f.mb_ticks.value = draft.mb_ticks ?? ""; if (f.letters_n) f.letters_n.value = draft.letters_n ?? "";
+    if (f.style) {
+      lastStyleSelection = f.style.value;
+      if (!userCanUseProMode() && f.style.value === "pro") {
+        toggleProAccessNotice(true);
+        f.style.value = "bar";
+        lastStyleSelection = f.style.value;
+      } else {
+        toggleProAccessNotice(false);
+      }
+    }
     if (f.smartMethod) f.smartMethod.value = draft.smartMethod || "manifold";
     if (f.smartUrl) f.smartUrl.value = draft.smartUrl || "";
     if (draft.startOverrideMs && typeof draft.startOverrideMs === "number"){
@@ -659,7 +726,6 @@
     ;['change','input'].forEach(ev=>{
       [f.days,f.hours,f.minutes,f.seconds,f.when,f.letters_n,f.startWhen,f.startPct]
         .forEach(el=> el && el.addEventListener(ev, updateLettersPreview));
-      if (f.style) f.style.addEventListener('change', updateStyleUI);
     });
     updateStyleUI();
 
@@ -696,13 +762,47 @@
   
   function updateUIForLoginState() {
     const isLoggedIn = !!currentUser;
-    accountControls.classList.toggle('invisible', isLoggedIn);
-    userSession.classList.toggle('invisible', !isLoggedIn);
-    if (isLoggedIn) {
-      userEmailDisplay.textContent = currentUser.email;
+    const role = getCurrentRole();
+    if (settingsSignedIn) settingsSignedIn.classList.toggle('invisible', !isLoggedIn);
+    if (settingsSignedOut) settingsSignedOut.classList.toggle('invisible', isLoggedIn);
+    if (settingsUserEmail) settingsUserEmail.textContent = isLoggedIn ? currentUser.email : "";
+    if (settingsRoleDisplay) {
+      if (isLoggedIn) {
+        settingsRoleDisplay.textContent = `Role: ${role}`;
+        settingsRoleDisplay.classList.remove('invisible');
+      } else {
+        settingsRoleDisplay.textContent = "";
+        settingsRoleDisplay.classList.add('invisible');
+      }
     }
+    if (settingsBtn) {
+      settingsBtn.title = isLoggedIn ? `Settings (${role})` : "Settings";
+      settingsBtn.dataset.role = role;
+    }
+    toggleProAccessNotice(false);
   }
-  
+
+  function openSettingsDialog() {
+    if (!settingsDialog) return;
+    updateUIForLoginState();
+    try {
+      settingsDialog.showModal ? settingsDialog.showModal() : settingsDialog.setAttribute("open", "");
+    } catch (e) {
+      settingsDialog.setAttribute("open", "");
+    }
+    if (settingsBtn) settingsBtn.setAttribute('aria-expanded', 'true');
+  }
+
+  function closeSettingsDialog() {
+    if (!settingsDialog) return;
+    try {
+      settingsDialog.close ? settingsDialog.close() : settingsDialog.removeAttribute("open");
+    } catch (e) {
+      settingsDialog.removeAttribute("open");
+    }
+    if (settingsBtn) settingsBtn.setAttribute('aria-expanded', 'false');
+  }
+
   function openAuthDialog(isSignUpMode = false) {
     const dialog = $("#authDialog");
     const title = $("#authTitle");
@@ -773,6 +873,7 @@
     const newUser = {
         email,
         password,
+        role: ROLE_STANDARD,
         timers: [], // Use JSON type, send empty array
         last_modified: new Date().toISOString() // Use DateTime type, send ISO string
     };
@@ -810,16 +911,17 @@
         return;
     }
 
-    currentUser = { id: user._id, email: user.email };
+    currentUser = { id: user._id, email: user.email, role: normalizeRole(user.role) };
     localStorage.setItem(KEY_USER, JSON.stringify(currentUser));
     updateUIForLoginState();
     authDialog.close();
-    
+
     await syncTimers();
   }
 
   function handleLogout() {
     if (confirm("Are you sure you want to log out? Your timers will remain on this device but will no longer sync.")) {
+      closeSettingsDialog();
       currentUser = null;
       localStorage.removeItem(KEY_USER);
       updateUIForLoginState();
@@ -830,8 +932,10 @@
   async function syncTimers() {
       if (!currentUser || isSyncing) return;
       isSyncing = true;
-      syncBtn.textContent = "Syncing...";
-      syncBtn.disabled = true;
+      if (settingsSyncBtn) {
+        settingsSyncBtn.textContent = "Syncing...";
+        settingsSyncBtn.disabled = true;
+      }
 
       try {
         const response = await fetch(`${RESTDB_URL}/${currentUser.id}`, {
@@ -841,6 +945,11 @@
         
         const remoteUser = await response.json();
         const remoteTimers = remoteUser.timers || [];
+        const remoteRoleRaw = remoteUser.role;
+        const remoteRole = (typeof remoteRoleRaw === "string" && remoteRoleRaw.trim()) ? normalizeRole(remoteRoleRaw) : getCurrentRole();
+        currentUser.role = remoteRole;
+        localStorage.setItem(KEY_USER, JSON.stringify(currentUser));
+        updateUIForLoginState();
         // RestDB returns DateTime as an ISO string. Date.parse() handles it correctly.
         const remoteTimestamp = remoteUser.last_modified ? Date.parse(remoteUser.last_modified) : 0;
         const localTimestamp = parseInt(localStorage.getItem(KEY_LAST_MODIFIED) || '0');
@@ -870,8 +979,10 @@
           alert("Sync failed. Please check your connection and try again.");
       } finally {
           isSyncing = false;
-          syncBtn.textContent = "Sync";
-          syncBtn.disabled = false;
+          if (settingsSyncBtn) {
+            settingsSyncBtn.textContent = "Sync Now";
+            settingsSyncBtn.disabled = false;
+          }
       }
   }
 
@@ -911,6 +1022,11 @@
       mb_ticks: f.mb_ticks.value? Math.max(8, Math.min(40, +f.mb_ticks.value)) : null,
       triggers, doneSoundDataUrl:null, doneTts: f.doneTts.value||""
     };
+    if (tpl.style === "pro" && !userCanUseProMode()) {
+      toggleProAccessNotice(true);
+      alert("Pro Mode is limited to Beta Tester or higher accounts.");
+      return;
+    }
     if (tpl.style === "pro"){
       tpl.splitStyles = [...PRO_SPLIT_STYLES];
       tpl.splitSettings = null;
@@ -930,6 +1046,11 @@
       mb_ticks: f.mb_ticks.value? Math.max(8, Math.min(40, +f.mb_ticks.value)) : null,
       letters_n: f.letters_n.value? Math.max(1, Math.min(7, +f.letters_n.value)) : null
     };
+    if (base.style === "pro" && !userCanUseProMode()) {
+      toggleProAccessNotice(true);
+      alert("Pro Mode is limited to Beta Tester or higher accounts.");
+      return;
+    }
     const existing = editId ? timers.find(x=>x.id===base.id) : null;
     const existingMap = new Map((existing?.triggers||[]).map(e=>[e.id,e]));
     const triggers = await collectTrEntries(existingMap);
@@ -1550,10 +1671,20 @@
     render(); // Pause is visual and doesn't need a full save/sync
   });
 
-  loginBtn.addEventListener('click', () => openAuthDialog(false));
-  signupBtn.addEventListener('click', () => openAuthDialog(true));
-  logoutBtn.addEventListener('click', handleLogout);
-  syncBtn.addEventListener('click', syncTimers);
+  if (settingsBtn) settingsBtn.addEventListener('click', () => openSettingsDialog());
+  if (settingsLoginBtn) settingsLoginBtn.addEventListener('click', () => {
+    closeSettingsDialog();
+    openAuthDialog(false);
+  });
+  if (settingsSignupBtn) settingsSignupBtn.addEventListener('click', () => {
+    closeSettingsDialog();
+    openAuthDialog(true);
+  });
+  if (settingsLogoutBtn) settingsLogoutBtn.addEventListener('click', handleLogout);
+  if (settingsSyncBtn) settingsSyncBtn.addEventListener('click', syncTimers);
+  if (settingsDialog) settingsDialog.addEventListener('close', () => {
+    if (settingsBtn) settingsBtn.setAttribute('aria-expanded', 'false');
+  });
   tplBtn.addEventListener("click", ()=> openTemplateMenu());
   document.addEventListener("click", (e)=>{ if(!templateMenu.contains(e.target) && e.target!==tplBtn){ templateMenu.classList.remove("open"); } });
   $("#authModeSwitch").addEventListener('click', (e) => {
@@ -1569,7 +1700,8 @@
     submitBtn.textContent = currentModeIsSignUp ? "Create Account" : "Log In";
   });
 
-  load(); 
+  updateUIForLoginState();
+  load();
   render(); 
   requestAnimationFrame(tick);
 })();

--- a/style.css
+++ b/style.css
@@ -7,6 +7,9 @@ header{position:sticky; top:0; z-index:10; background:linear-gradient(180deg, rg
 .brand{font-weight:800}
 .spacer{flex:1}
 .btn{border:1px solid rgba(255,255,255,.14); background:#191b26; color:var(--text); padding:.55rem .8rem; border-radius:12px; cursor:pointer; font-weight:600;}
+.btn.icon{display:flex; align-items:center; gap:.45rem;}
+.btn.icon .icon{font-size:1.1rem; line-height:1;}
+.btn.icon .label{line-height:1;}
 .btn.primary{background:var(--accent); color:#0b0c10; border-color:transparent}
 .controls{display:flex; gap:.5rem; align-items:center; flex-wrap:wrap}
 select, input{background:#171925; color:var(--text); border:1px solid rgba(255,255,255,.12); border-radius:12px; padding:.45rem .6rem;}
@@ -29,6 +32,12 @@ dialog{width:min(980px,96vw); border:none; border-radius:16px; background:#12142
 dialog::backdrop{background:rgba(0,0,0,.6)}
 .dialog-header{display:flex; align-items:center; justify-content:space-between; padding:12px 14px; border-bottom:1px solid rgba(255,255,255,.08); gap:8px; flex-wrap:wrap}
 .dialog-body{padding:12px 14px; display:grid; gap:10px; overflow-x:hidden}
+.settings-body{gap:16px;}
+.settings-section{display:grid; gap:12px;}
+.settings-actions{display:flex; gap:10px; flex-wrap:wrap; align-items:center;}
+.settings-summary{display:grid; gap:4px;}
+.settings-value{font-weight:700;}
+.settings-role{margin-top:auto; font-size:.9rem; color:var(--muted); border-top:1px solid rgba(255,255,255,.08); padding-top:12px;}
 .field{display:grid; gap:6px; min-width:0}
 .field-row{display:grid; grid-template-columns:1fr 1fr; gap:10px}
 .note{font-size:.85rem; color:var(--muted)}


### PR DESCRIPTION
## Summary
- replace the header auth buttons with a gear-driven settings dialog that consolidates login, signup, logout, and sync
- persist and surface the new account role field so users can see their role in the settings dialog
- gate Pro Mode selection, template saving, and timer saving to Beta Tester, Special Access, or Owner roles with clear messaging

## Testing
- Not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68fa811db6f8832d99352399e8db4f2f