### PR TITLE
Update role integration to use Accounts Role field

### DIFF
--- a/script.js
+++ b/script.js
@@ -103,18 +103,33 @@
     color: "Color"
   };
   const ROLE_STANDARD = "Standard";
+  const ROLE_CANONICAL = {
+    owner: "Owner",
+    "beta tester": "Beta Tester",
+    "special access": "Special Access",
+    standard: ROLE_STANDARD
+  };
   const PRO_MODE_ROLES = new Set(["beta tester", "special access", "owner"]);
 
   function normalizeRole(role) {
     if (typeof role === "string") {
       const trimmed = role.trim();
-      if (trimmed) return trimmed;
+      if (trimmed) {
+        const canonical = ROLE_CANONICAL[trimmed.toLowerCase()];
+        return canonical || trimmed;
+      }
     }
     return ROLE_STANDARD;
   }
 
+  function extractRoleFromRecord(record) {
+    if (!record || typeof record !== "object") return ROLE_STANDARD;
+    const rawRole = record.Role ?? record.role;
+    return normalizeRole(rawRole);
+  }
+
   function getCurrentRole() {
-    return currentUser?.role ? normalizeRole(currentUser.role) : ROLE_STANDARD;
+    return currentUser ? extractRoleFromRecord(currentUser) : ROLE_STANDARD;
   }
 
   function userCanUseProMode() {
@@ -147,7 +162,9 @@
       if (userRaw) {
         currentUser = JSON.parse(userRaw);
         if (currentUser) {
-          currentUser.role = normalizeRole(currentUser.role);
+          const storedRole = currentUser.role ?? currentUser.Role;
+          currentUser.role = normalizeRole(storedRole);
+          delete currentUser.Role;
           localStorage.setItem(KEY_USER, JSON.stringify(currentUser));
         }
         updateUIForLoginState();
@@ -873,7 +890,7 @@
     const newUser = {
         email,
         password,
-        role: ROLE_STANDARD,
+        Role: ROLE_STANDARD,
         timers: [], // Use JSON type, send empty array
         last_modified: new Date().toISOString() // Use DateTime type, send ISO string
     };
@@ -911,7 +928,7 @@
         return;
     }
 
-    currentUser = { id: user._id, email: user.email, role: normalizeRole(user.role) };
+    currentUser = { id: user._id, email: user.email, role: extractRoleFromRecord(user) };
     localStorage.setItem(KEY_USER, JSON.stringify(currentUser));
     updateUIForLoginState();
     authDialog.close();
@@ -945,8 +962,7 @@
         
         const remoteUser = await response.json();
         const remoteTimers = remoteUser.timers || [];
-        const remoteRoleRaw = remoteUser.role;
-        const remoteRole = (typeof remoteRoleRaw === "string" && remoteRoleRaw.trim()) ? normalizeRole(remoteRoleRaw) : getCurrentRole();
+        const remoteRole = extractRoleFromRecord(remoteUser);
         currentUser.role = remoteRole;
         localStorage.setItem(KEY_USER, JSON.stringify(currentUser));
         updateUIForLoginState();


### PR DESCRIPTION
## Summary
- normalize account roles to canonical values and support the RestDB `Role` field
- read role information from Accounts documents during login and sync flows
- ensure new accounts initialize `Role` as Standard while cleaning stored session data

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fa893b8e08832d8b59876df94a063a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced user role consistency and synchronization across sign-up, login, and data storage operations.

* **Bug Fixes**
  * Resolved role field inconsistencies in user data persistence and synchronization flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->