### PR TITLE
Fix account sync to avoid wiping credentials

### DIFF
--- a/script.js
+++ b/script.js
@@ -1048,7 +1048,7 @@
     
     try {
       const response = await fetch(`${RESTDB_URL}/${currentUser.id}`, {
-        method: 'PUT',
+        method: 'PATCH',
         headers: { 'x-apikey': API_KEY, 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
       });


### PR DESCRIPTION
## Summary
- switch the sync update request to PATCH so we update only the timers payload
- prevent overwriting existing account fields during cloud sync

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb84e59ac4832db28138a6dc7bef8b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote timer synchronization to use partial updates, ensuring only modified properties are transmitted to the cloud during sync operations, resulting in more efficient resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->