### PR TITLE
Fix syncing for legacy user ids

### DIFF
--- a/script.js
+++ b/script.js
@@ -162,6 +162,10 @@
       if (userRaw) {
         currentUser = JSON.parse(userRaw);
         if (currentUser) {
+          if (!currentUser.id && currentUser._id) {
+            currentUser.id = currentUser._id;
+          }
+          delete currentUser._id;
           const storedRole = currentUser.role ?? currentUser.Role;
           currentUser.role = normalizeRole(storedRole);
           delete currentUser.Role;
@@ -947,7 +951,7 @@
   }
   
   async function syncTimers() {
-      if (!currentUser || isSyncing) return;
+      if (!currentUser || !currentUser.id || isSyncing) return;
       isSyncing = true;
       if (settingsSyncBtn) {
         settingsSyncBtn.textContent = "Syncing...";
@@ -1027,7 +1031,10 @@
   }
 
   async function pushTimersToCloud(timersArray, timestampNumber) {
-    if (!currentUser) return;
+    if (!currentUser || !currentUser.id) {
+      console.warn("Skipping cloud push because the current user record is missing an id.");
+      return;
+    }
     
     const timestampValue = Number(timestampNumber);
     let safeTimestamp = Number.isFinite(timestampValue) ? timestampValue : null;


### PR DESCRIPTION
## Summary
- migrate stored user records that still use the legacy `_id` field to the new `id` field so RestDB requests succeed
- guard sync and push operations when the current user is missing an id to avoid bad requests

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb9940c810832db2164316f2b8c7c6