### PR TITLE
Proxy RestDB traffic through Cloudflare function

### DIFF
--- a/functions/api/[[path]].js
+++ b/functions/api/[[path]].js
@@ -1,0 +1,79 @@
+export async function onRequest(context) {
+  const { request, env, params } = context;
+  const incomingUrl = new URL(request.url);
+
+  if (request.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: buildCorsHeaders(incomingUrl.origin),
+    });
+  }
+
+  const pathParam = params.path ? `/${params.path}` : "";
+  const allowedPrefix = "/accounts";
+  if (!pathParam.startsWith(allowedPrefix)) {
+    return new Response("Not Found", { status: 404 });
+  }
+
+  const targetUrl = new URL(`https://timerapp-1f65.restdb.io/rest${pathParam}`);
+  targetUrl.search = incomingUrl.search;
+
+  const init = await buildRequestInit(request, env.API_KEY);
+  const response = await fetch(targetUrl.toString(), init);
+
+  return buildResponse(response, incomingUrl.origin);
+}
+
+function buildCorsHeaders(origin) {
+  return {
+    "Access-Control-Allow-Origin": origin,
+    "Access-Control-Allow-Methods": "GET,POST,PUT,DELETE,OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+  };
+}
+
+async function buildRequestInit(request, apiKey) {
+  const headers = new Headers();
+  const hopByHop = new Set(["host", "cf-ray", "cf-connecting-ip", "x-apikey", "connection"]);
+  request.headers.forEach((value, key) => {
+    const lowerKey = key.toLowerCase();
+    if (!hopByHop.has(lowerKey)) {
+      headers.set(key, value);
+    }
+  });
+  headers.set("x-apikey", apiKey);
+
+  const init = {
+    method: request.method,
+    headers,
+  };
+
+  if (!isBodylessMethod(request.method)) {
+    const contentType = request.headers.get("content-type") || "";
+    if (contentType.includes("application/json")) {
+      headers.set("content-type", "application/json");
+      init.body = await request.text();
+    } else if (contentType) {
+      init.body = await request.arrayBuffer();
+    }
+  }
+
+  return init;
+}
+
+function isBodylessMethod(method) {
+  return method === "GET" || method === "HEAD";
+}
+
+async function buildResponse(response, origin) {
+  const headers = new Headers(response.headers);
+  ["transfer-encoding", "content-encoding", "connection"].forEach((header) =>
+    headers.delete(header)
+  );
+  headers.set("Access-Control-Allow-Origin", origin);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/script.js
+++ b/script.js
@@ -22,8 +22,7 @@
   }
 
   // --- START: Authentication and Sync Configuration ---
-  const RESTDB_URL = 'https://timerapp-1f65.restdb.io/rest/accounts'; // <-- IMPORTANT: SET THIS
-  const API_KEY = '68a65f75b349a309704b6cab'; // <-- IMPORTANT: SET THIS
+  const RESTDB_URL = '/api/accounts'; // Requests proxied through Cloudflare Pages Function
   
   let currentUser = null;
   let isSyncing = false;
@@ -881,9 +880,7 @@
   }
 
   async function handleSignUp(email, password) {
-    const checkResponse = await fetch(`${RESTDB_URL}?q={"email":"${email}"}`, {
-        headers: { 'x-apikey': API_KEY }
-    });
+    const checkResponse = await fetch(`${RESTDB_URL}?q={"email":"${email}"}`);
     if (!checkResponse.ok) throw new Error("Network error checking user.");
     const existingUsers = await checkResponse.json();
     if (existingUsers.length > 0) {
@@ -901,7 +898,7 @@
     
     const createResponse = await fetch(RESTDB_URL, {
         method: 'POST',
-        headers: { 'x-apikey': API_KEY, 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(newUser)
     });
 
@@ -915,9 +912,7 @@
   }
 
   async function handleLogin(email, password) {
-    const response = await fetch(`${RESTDB_URL}?q={"email":"${email}"}`, {
-        headers: { 'x-apikey': API_KEY, }
-    });
+    const response = await fetch(`${RESTDB_URL}?q={"email":"${email}"}`);
     if (!response.ok) throw new Error("Network error fetching user.");
     const users = await response.json();
 
@@ -959,9 +954,7 @@
       }
 
       try {
-        const response = await fetch(`${RESTDB_URL}/${currentUser.id}`, {
-            headers: { 'x-apikey': API_KEY, 'Content-Type': 'application/json' }
-        });
+        const response = await fetch(`${RESTDB_URL}/${currentUser.id}`);
         if (!response.ok) throw new Error("Could not fetch remote data.");
         
         const remoteUser = await response.json();
@@ -1056,7 +1049,7 @@
     try {
       const response = await fetch(`${RESTDB_URL}/${currentUser.id}`, {
         method: 'PATCH',
-        headers: { 'x-apikey': API_KEY, 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
       });
       if (!response.ok) {


### PR DESCRIPTION
## Summary
- add a Cloudflare Pages function that proxies RestDB requests and injects the API key secret
- update the frontend to call the proxied endpoint so the key is no longer exposed client-side

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68fc1a651f3c832db0c23808421a992b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced secure API proxy for all account operations (sign-up, login, data fetch and updates) with automatic CORS header handling.

* **Infrastructure**
  * Implemented centralized request handling and response processing through a new serverless endpoint with built-in path validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->