### PR TITLE
Handle missing sync API gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# Hyper Timer Deployment Guide
+
+This project expects to run on [Cloudflare Pages](https://developers.cloudflare.com/pages/) so it can use the bundled Pages Function in `functions/api/[[path]].js` as a proxy to the RestDB `accounts` API. If the site is hosted on a different platform (for example GitHub Pages), requests to `/api/accounts` will respond with `404 Not Found` because the Cloudflare runtime is not available. Follow the steps below to connect your deployment to your Cloudflare account and enable the sync features.
+
+## 1. Prepare your Cloudflare account
+
+1. Sign in to the Cloudflare dashboard and ensure you have the **Pages** product available on the account you plan to use.
+2. If you have not already, create a Cloudflare **API Token** with *Edit Cloudflare Workers* and *Edit Cloudflare Pages* permissions so you can deploy from GitHub (optional but recommended).
+
+## 2. Create a Pages project for Hyper Timer
+
+1. In the Cloudflare dashboard go to **Workers & Pages → Pages** and click **Create a project**.
+2. Choose **Connect to Git** and authorize Cloudflare to access the GitHub repository that contains this codebase.
+3. Select the repository (e.g. `egga22/Hyper-Timer`) and accept the default build settings:
+   - **Framework preset:** `None`
+   - **Build command:** leave empty (this is a static site)
+   - **Build output directory:** `.`
+4. Toggle **Functions** on when prompted so that Cloudflare deploys the `functions/api/[[path]].js` handler.
+
+After the project is created, Cloudflare will deploy the site to a `*.pages.dev` URL. You can later add your custom domain in the Pages project settings.
+
+## 3. Configure the RestDB API key
+
+The proxy function forwards requests to `https://timerapp-1f65.restdb.io/rest/accounts` using an API key stored in the `API_KEY` environment variable.
+
+1. In the Pages project, open **Settings → Functions → Environment variables**.
+2. Add a variable named `API_KEY` and set its value to your RestDB API key.
+3. Re-deploy the project (trigger **Save and deploy** in the UI or push a new commit) so the function picks up the environment variable.
+
+## 4. Verify the proxy
+
+Once the deployment finishes:
+
+1. Visit `https://<your-pages-project>.pages.dev/api/accounts` in the browser (you should see JSON instead of a 404 page).
+2. Load the main application (`/Hyper-Timer/`) and open the developer tools network tab to confirm the calls to `/api/accounts` return `200` responses.
+
+If you see authentication errors (HTTP 401/403), double-check that the RestDB API key has read/write permissions for the `accounts` collection. If you still receive a `404`, make sure the request is being sent to your Cloudflare Pages domain and not to GitHub Pages.
+
+## 5. Optional: Using Wrangler for local testing
+
+If you want to test locally with the Cloudflare runtime:
+
+1. Install the [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/) and run `wrangler pages dev --compatibility-flag nodejs_compat` from the project root.
+2. Set the `API_KEY` variable for the dev session with `wrangler pages dev --var API_KEY=<your-key>` or by adding it to a `.dev.vars` file.
+3. Access the local URL provided by Wrangler; it will emulate the Pages Function so `/api/accounts` works during development.
+
+By completing these steps, the application will be connected to your Cloudflare account and the sync features will function correctly.

--- a/script.js
+++ b/script.js
@@ -23,6 +23,11 @@
 
   // --- START: Authentication and Sync Configuration ---
   const RESTDB_URL = '/api/accounts'; // Requests proxied through Cloudflare Pages Function
+  const SYNC_UNAVAILABLE_ERROR = 'hyper-timer-sync-unavailable';
+  const SYNC_UNAVAILABLE_MESSAGE = "Cloud sync isn't available on this version of HyperTimer. Timers will continue to be saved locally on this device.";
+
+  let syncServiceAvailable = true;
+  let hasAnnouncedSyncUnavailable = false;
   
   let currentUser = null;
   let isSyncing = false;
@@ -50,6 +55,80 @@
   const settingsRoleDisplay = $("#settingsRoleDisplay");
   const proAccessNotice = $("#proAccessNotice");
   const authDialog = $("#authDialog");
+
+  function notifySyncUnavailable() {
+    if (hasAnnouncedSyncUnavailable) return;
+    alert(SYNC_UNAVAILABLE_MESSAGE);
+    hasAnnouncedSyncUnavailable = true;
+  }
+
+  function disableSyncUiElements() {
+    if (settingsSignedOut) {
+      const infoNote = settingsSignedOut.querySelector('.note');
+      if (infoNote) {
+        infoNote.textContent = "Cloud sync is unavailable on this site. Timers will continue to save locally.";
+      }
+      if (settingsLoginBtn) {
+        settingsLoginBtn.disabled = true;
+        settingsLoginBtn.setAttribute('aria-disabled', 'true');
+      }
+      if (settingsSignupBtn) {
+        settingsSignupBtn.disabled = true;
+        settingsSignupBtn.setAttribute('aria-disabled', 'true');
+      }
+    }
+    if (settingsSignedIn) {
+      let existingNotice = settingsSignedIn.querySelector('[data-sync-unavailable]');
+      if (!existingNotice) {
+        existingNotice = document.createElement('div');
+        existingNotice.className = 'note';
+        existingNotice.dataset.syncUnavailable = 'true';
+        existingNotice.textContent = SYNC_UNAVAILABLE_MESSAGE;
+        settingsSignedIn.appendChild(existingNotice);
+      } else {
+        existingNotice.textContent = SYNC_UNAVAILABLE_MESSAGE;
+      }
+    }
+    if (settingsSyncBtn) {
+      settingsSyncBtn.textContent = 'Sync Unavailable';
+      settingsSyncBtn.disabled = true;
+      settingsSyncBtn.setAttribute('aria-disabled', 'true');
+    }
+    if (authDialog && typeof authDialog.close === 'function' && authDialog.open) {
+      try {
+        authDialog.close();
+      } catch (e) {
+        authDialog.removeAttribute('open');
+      }
+    }
+  }
+
+  function markSyncServiceUnavailable() {
+    if (!syncServiceAvailable) return;
+    syncServiceAvailable = false;
+    disableSyncUiElements();
+  }
+
+  function isApiUnavailableResponse(response) {
+    if (!response || response.status !== 404) return false;
+    const contentType = response.headers.get('content-type') || '';
+    return contentType.includes('text/html');
+  }
+
+  function createSyncUnavailableError() {
+    const error = new Error(SYNC_UNAVAILABLE_ERROR);
+    error.code = SYNC_UNAVAILABLE_ERROR;
+    return error;
+  }
+
+  async function safeApiFetch(url, options) {
+    const response = await fetch(url, options);
+    if (isApiUnavailableResponse(response)) {
+      markSyncServiceUnavailable();
+      throw createSyncUnavailableError();
+    }
+    return response;
+  }
 
   const f = {
     name: $("#f_name"), mode: $("#f_mode"), when: $("#f_when"),
@@ -178,7 +257,7 @@
       if (rt){ const data = JSON.parse(rt); if (Array.isArray(data)) templates = data.map(migrateTemplate); }
     } catch(e){ console.warn("load failed", e); }
     if (currentUser) {
-        syncTimers();
+        syncTimers({ silentIfUnavailable: true });
     }
     refreshSmartTimers();
   }
@@ -824,6 +903,10 @@
   }
 
   function openAuthDialog(isSignUpMode = false) {
+    if (!syncServiceAvailable) {
+      notifySyncUnavailable();
+      return;
+    }
     const dialog = $("#authDialog");
     const title = $("#authTitle");
     const submitBtn = $("#authSubmitBtn");
@@ -870,8 +953,12 @@
         await handleLogin(email, password);
       }
     } catch (error) {
-        console.error("Auth error:", error);
-        alert("An error occurred. Please try again.");
+        if (error && error.code === SYNC_UNAVAILABLE_ERROR) {
+          notifySyncUnavailable();
+        } else {
+          console.error("Auth error:", error);
+          alert("An error occurred. Please try again.");
+        }
     } finally {
         submitBtn.disabled = false;
         const currentModeIsSignUp = $("#authTitle").textContent === "Sign Up";
@@ -880,7 +967,7 @@
   }
 
   async function handleSignUp(email, password) {
-    const checkResponse = await fetch(`${RESTDB_URL}?q={"email":"${email}"}`);
+    const checkResponse = await safeApiFetch(`${RESTDB_URL}?q={"email":"${email}"}`);
     if (!checkResponse.ok) throw new Error("Network error checking user.");
     const existingUsers = await checkResponse.json();
     if (existingUsers.length > 0) {
@@ -896,7 +983,7 @@
         last_modified: new Date().toISOString() // Use DateTime type, send ISO string
     };
     
-    const createResponse = await fetch(RESTDB_URL, {
+    const createResponse = await safeApiFetch(RESTDB_URL, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(newUser)
@@ -912,7 +999,7 @@
   }
 
   async function handleLogin(email, password) {
-    const response = await fetch(`${RESTDB_URL}?q={"email":"${email}"}`);
+    const response = await safeApiFetch(`${RESTDB_URL}?q={"email":"${email}"}`);
     if (!response.ok) throw new Error("Network error fetching user.");
     const users = await response.json();
 
@@ -945,8 +1032,15 @@
     }
   }
   
-  async function syncTimers() {
+  async function syncTimers(options = {}) {
       if (!currentUser || !currentUser.id || isSyncing) return;
+      const { silentIfUnavailable = false } = options;
+      if (!syncServiceAvailable) {
+        if (!silentIfUnavailable) {
+          notifySyncUnavailable();
+        }
+        return;
+      }
       isSyncing = true;
       if (settingsSyncBtn) {
         settingsSyncBtn.textContent = "Syncing...";
@@ -954,9 +1048,9 @@
       }
 
       try {
-        const response = await fetch(`${RESTDB_URL}/${currentUser.id}`);
+        const response = await safeApiFetch(`${RESTDB_URL}/${currentUser.id}`);
         if (!response.ok) throw new Error("Could not fetch remote data.");
-        
+
         const remoteUser = await response.json();
         const remoteTimers = remoteUser.timers || [];
         const remoteRole = extractRoleFromRecord(remoteUser);
@@ -1010,15 +1104,32 @@
             console.log("Sync: Local and remote are up to date.");
         }
         await refreshSmartTimers();
-        alert('Sync complete!');
+        if (!silentIfUnavailable) {
+          alert('Sync complete!');
+        }
       } catch (error) {
-          console.error("Sync failed:", error);
-          alert("Sync failed. Please check your connection and try again.");
+          if (error && error.code === SYNC_UNAVAILABLE_ERROR) {
+            if (!silentIfUnavailable) {
+              notifySyncUnavailable();
+            }
+          } else {
+            console.error("Sync failed:", error);
+            if (!silentIfUnavailable) {
+              alert("Sync failed. Please check your connection and try again.");
+            }
+          }
       } finally {
           isSyncing = false;
           if (settingsSyncBtn) {
-            settingsSyncBtn.textContent = "Sync Now";
-            settingsSyncBtn.disabled = false;
+            if (syncServiceAvailable) {
+              settingsSyncBtn.textContent = "Sync Now";
+              settingsSyncBtn.disabled = false;
+              settingsSyncBtn.removeAttribute('aria-disabled');
+            } else {
+              settingsSyncBtn.textContent = 'Sync Unavailable';
+              settingsSyncBtn.disabled = true;
+              settingsSyncBtn.setAttribute('aria-disabled', 'true');
+            }
           }
       }
   }
@@ -1047,7 +1158,7 @@
     };
     
     try {
-      const response = await fetch(`${RESTDB_URL}/${currentUser.id}`, {
+      const response = await safeApiFetch(`${RESTDB_URL}/${currentUser.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
@@ -1057,7 +1168,11 @@
       }
       console.log("Successfully pushed changes to the cloud.");
     } catch (error) {
-      console.error("Failed to push changes to the cloud:", error);
+      if (error && error.code === SYNC_UNAVAILABLE_ERROR) {
+        console.warn("Skipping cloud sync push because the remote service is unavailable.");
+      } else {
+        console.error("Failed to push changes to the cloud:", error);
+      }
     }
   }
   // --- END: Authentication and Sync Functions ---
@@ -1725,15 +1840,23 @@
 
   if (settingsBtn) settingsBtn.addEventListener('click', () => openSettingsDialog());
   if (settingsLoginBtn) settingsLoginBtn.addEventListener('click', () => {
+    if (!syncServiceAvailable) {
+      notifySyncUnavailable();
+      return;
+    }
     closeSettingsDialog();
     openAuthDialog(false);
   });
   if (settingsSignupBtn) settingsSignupBtn.addEventListener('click', () => {
+    if (!syncServiceAvailable) {
+      notifySyncUnavailable();
+      return;
+    }
     closeSettingsDialog();
     openAuthDialog(true);
   });
   if (settingsLogoutBtn) settingsLogoutBtn.addEventListener('click', handleLogout);
-  if (settingsSyncBtn) settingsSyncBtn.addEventListener('click', syncTimers);
+  if (settingsSyncBtn) settingsSyncBtn.addEventListener('click', () => syncTimers());
   if (settingsDialog) settingsDialog.addEventListener('close', () => {
     if (settingsBtn) settingsBtn.setAttribute('aria-expanded', 'false');
   });


### PR DESCRIPTION
## Summary
- detect when the Cloudflare proxy for the accounts API is unavailable and disable sync-related UI
- add a shared helper for account API requests that marks the sync service as offline and prevents repeated alerts
- adjust sync routines to support silent checks on load and avoid cloud calls when the service is offline

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fc1ef789c0832d943db77024477f02

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote sync with graceful fallback and a silent-if-unavailable option for background sync.

* **Bug Fixes**
  * Clearer auth and sync error messaging that surfaces "Sync Unavailable" instead of generic errors.

* **Improvements**
  * UI reflects sync availability (labels, disabled states, notifications) and gates actions when sync is down; sync now prefers remote/local based on timestamps.

* **Documentation**
  * Added deployment guide for Cloudflare Pages integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->