### PR TITLE
Restrict Pro Mode option to eligible roles

### DIFF
--- a/script.js
+++ b/script.js
@@ -74,17 +74,14 @@
     });
     f.style.addEventListener("change", () => {
       if (f.style.value === "pro" && !userCanUseProMode()) {
-        const fallback = lastStyleSelection === "pro" ? "bar" : (lastStyleSelection || "bar");
-        f.style.value = fallback;
-        lastStyleSelection = f.style.value;
-        toggleProAccessNotice(true);
-        updateStyleUI();
+        enforceProModeEligibility(true);
         return;
       }
       lastStyleSelection = f.style.value;
       toggleProAccessNotice(false);
       updateStyleUI();
     });
+    enforceProModeEligibility(false);
   }
   toggleProAccessNotice(false);
 
@@ -140,6 +137,38 @@
   function toggleProAccessNotice(show) {
     if (!proAccessNotice) return;
     proAccessNotice.classList.toggle("invisible", !show);
+  }
+
+  function enforceProModeEligibility(showNotice = false) {
+    if (!f.style) return;
+    const proOption = f.style.querySelector('option[value="pro"]');
+    const allowed = userCanUseProMode();
+    if (proOption) {
+      proOption.disabled = !allowed;
+      proOption.hidden = !allowed;
+      if (!allowed) {
+        proOption.setAttribute("aria-hidden", "true");
+      } else {
+        proOption.removeAttribute("aria-hidden");
+      }
+    }
+    if (!allowed) {
+      if (f.style.value === "pro") {
+        const fallback = lastStyleSelection === "pro" ? "bar" : (lastStyleSelection || "bar");
+        f.style.value = fallback;
+        lastStyleSelection = f.style.value;
+        if (showNotice) {
+          toggleProAccessNotice(true);
+        } else {
+          toggleProAccessNotice(false);
+        }
+        updateStyleUI();
+      } else if (!showNotice) {
+        toggleProAccessNotice(false);
+      }
+    } else {
+      toggleProAccessNotice(false);
+    }
   }
 
   async function updateAndSaveTimers(newTimersArray = null) {
@@ -722,11 +751,9 @@
     if (f.style) {
       lastStyleSelection = f.style.value;
       if (!userCanUseProMode() && f.style.value === "pro") {
-        toggleProAccessNotice(true);
-        f.style.value = "bar";
-        lastStyleSelection = f.style.value;
+        enforceProModeEligibility(true);
       } else {
-        toggleProAccessNotice(false);
+        enforceProModeEligibility(false);
       }
     }
     if (f.smartMethod) f.smartMethod.value = draft.smartMethod || "manifold";
@@ -801,6 +828,7 @@
       settingsBtn.dataset.role = role;
     }
     toggleProAccessNotice(false);
+    enforceProModeEligibility(false);
   }
 
   function openSettingsDialog() {


### PR DESCRIPTION
## Summary
- hide and disable the Pro Mode style option for users without a qualifying role
- centralize Pro Mode eligibility checks so unauthorized users fall back to standard styles when editing timers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69060a843b34832d8aa715854cd1e64e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in Pro mode access handling across different screens and workflows.
  * Enhanced notifications and UI behavior when Pro features are unavailable due to access restrictions.
  * Refined fallback behavior when Pro options are not accessible to the user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->