### PR TITLE
Fix pro mode eligibility initialization for anonymous users

### DIFF
--- a/script.js
+++ b/script.js
@@ -109,7 +109,6 @@
       toggleProAccessNotice(false);
       updateStyleUI();
     });
-    enforceProModeEligibility(false);
   }
   toggleProAccessNotice(false);
 
@@ -197,6 +196,10 @@
     } else {
       toggleProAccessNotice(false);
     }
+  }
+
+  if (f.style) {
+    enforceProModeEligibility(false);
   }
 
   async function updateAndSaveTimers(newTimersArray = null) {


### PR DESCRIPTION
## Summary
- avoid running the pro mode eligibility check before role constants initialize
- run the eligibility check after role helpers are defined to keep access control intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69061510bb20832d84bc9bf3a14af69c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Pro Mode eligibility validation by moving the check to occur earlier during application initialization, ensuring proper mode detection upon startup when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->