### PR TITLE
Fix sync request headers for RestDB

### DIFF
--- a/script.js
+++ b/script.js
@@ -1019,7 +1019,7 @@
 
       try {
         const response = await fetch(`${RESTDB_URL}/${currentUser.id}`, {
-            headers: { 'x-apikey': API_KEY, 'Content-Type': 'application/json' }
+            headers: { 'x-apikey': API_KEY }
         });
         if (!response.ok) throw new Error("Could not fetch remote data.");
         


### PR DESCRIPTION
## Summary
- remove the unnecessary Content-Type header from the sync fetch request so RestDB no longer rejects the call

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_69061d701e50832da7bc84bf3282f3b1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted request headers for remote data fetching operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->