### PR TITLE
Store account settings in new field

### DIFF
--- a/script.js
+++ b/script.js
@@ -1323,13 +1323,15 @@
         return;
     }
 
+    const initialSettings = sanitizePreferences(DEFAULT_PREFERENCES);
     const newUser = {
         email,
         password,
         Role: ROLE_STANDARD,
         timers: [], // Use JSON type, send empty array
         last_modified: new Date().toISOString(), // Use DateTime type, send ISO string
-        preferences: { ...DEFAULT_PREFERENCES }
+        Settings: initialSettings,
+        preferences: initialSettings
     };
     
     const createResponse = await fetch(RESTDB_URL, {
@@ -1428,7 +1430,9 @@
         localStorage.setItem(KEY_USER, JSON.stringify(currentUser));
         updateUIForLoginState();
 
-        const remotePreferencesRaw = remoteUser && typeof remoteUser === "object" ? remoteUser.preferences : null;
+        const remotePreferencesRaw = remoteUser && typeof remoteUser === "object"
+          ? (remoteUser.Settings ?? remoteUser.settings ?? remoteUser.preferences)
+          : null;
         const sanitizedRemotePreferences = remotePreferencesRaw && typeof remotePreferencesRaw === "object"
           ? sanitizePreferences(remotePreferencesRaw)
           : null;
@@ -1630,10 +1634,12 @@
       safeTimestamp = Date.now();
     }
 
+    const sanitizedPrefs = sanitizePreferences(userPreferences);
     const payload = {
       timers: timersArray,
       last_modified: new Date(safeTimestamp).toISOString(),
-      preferences: sanitizePreferences(userPreferences)
+      Settings: sanitizedPrefs,
+      preferences: sanitizedPrefs
     };
 
     try {
@@ -1662,7 +1668,8 @@
       return false;
     }
     try {
-      await patchAccount({ preferences: sanitizePreferences(userPreferences) });
+      const sanitizedPrefs = sanitizePreferences(userPreferences);
+      await patchAccount({ Settings: sanitizedPrefs, preferences: sanitizedPrefs });
       return true;
     } catch (error) {
       if (error.message === "no-current-user") {


### PR DESCRIPTION
## Summary
- persist timer default preferences into the new `Settings` field on account creation and updates
- include a backwards-compatible fallback when reading preferences so existing accounts continue to load defaults

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69068fb93704832db225921f3e38ac7d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cloud synchronization of user preferences and settings for more consistent data across sign-in and sign-up flows.
  * Enhanced backward compatibility when retrieving existing user preference data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->