### PR TITLE
Add short term schedule week start selector

### DIFF
--- a/script.js
+++ b/script.js
@@ -1432,6 +1432,8 @@
             checkbox.checked = true;
             syncWeekdaysFromInputs();
           }
+          refreshStartWeekSelection();
+          commitStartWeek();
         });
         const span = document.createElement("span");
         span.textContent = name.slice(0, 3);
@@ -1451,6 +1453,8 @@
           event.hour = parsed.hour;
           event.minute = parsed.minute;
           delete event.anchorWeekStart;
+          refreshStartWeekSelection();
+          commitStartWeek();
         }
       });
       body.appendChild(timeInput);
@@ -1474,7 +1478,94 @@
         const display = Number.isFinite(value) ? value : 1;
         intervalSuffix.textContent = display === 1 ? "week" : "weeks";
       };
+
+      const getIntervalWeeks = () => {
+        let numeric = Math.floor(Number(intervalInput.value));
+        if (!Number.isFinite(numeric) || numeric < 1) {
+          numeric = Math.floor(Number(event.intervalWeeks ?? intervalWeeks));
+        }
+        if (!Number.isFinite(numeric) || numeric < 1) {
+          numeric = 1;
+        }
+        return numeric;
+      };
+
+      const startWeekContainer = document.createElement("div");
+      startWeekContainer.className = "shortterm-weekstart";
+
+      const startWeekLabel = document.createElement("span");
+      startWeekLabel.textContent = "Start on";
+      startWeekContainer.appendChild(startWeekLabel);
+
+      const startWeekSelect = document.createElement("select");
+      startWeekSelect.setAttribute("aria-label", "Select which week the rotation starts");
+      startWeekContainer.appendChild(startWeekSelect);
+
+      const computeStartWeekOffset = interval => {
+        if (!Number.isFinite(interval) || interval < 1) return 0;
+        const baseWeek = normalizeWeekStartTimestamp(now());
+        let anchor = Number(event.anchorWeekStart);
+        if (Number.isFinite(anchor)) {
+          anchor = normalizeWeekStartTimestamp(anchor);
+        } else {
+          anchor = NaN;
+        }
+        if (!Number.isFinite(anchor)) return 0;
+        if (anchor >= baseWeek) {
+          const diffWeeks = Math.round((anchor - baseWeek) / WEEK_MS);
+          return ((diffWeeks % interval) + interval) % interval;
+        }
+        const diffWeeks = Math.round((baseWeek - anchor) / WEEK_MS);
+        return (interval - (diffWeeks % interval)) % interval;
+      };
+
+      const refreshStartWeekSelection = () => {
+        const interval = getIntervalWeeks();
+        startWeekSelect.innerHTML = "";
+        if (interval <= 1) {
+          startWeekContainer.classList.add("invisible");
+          return;
+        }
+        startWeekContainer.classList.remove("invisible");
+        for (let i = 0; i < interval; i++) {
+          const option = document.createElement("option");
+          option.value = String(i);
+          if (i === 0) {
+            option.textContent = "Start this week";
+          } else if (i === 1) {
+            option.textContent = "Start next week";
+          } else {
+            option.textContent = `Start in ${i} weeks`;
+          }
+          startWeekSelect.appendChild(option);
+        }
+        const offset = computeStartWeekOffset(interval);
+        if (startWeekSelect.querySelector(`option[value="${offset}"]`)) {
+          startWeekSelect.value = String(offset);
+        } else {
+          startWeekSelect.value = "0";
+        }
+      };
+
+      const commitStartWeek = () => {
+        const interval = getIntervalWeeks();
+        if (interval <= 1) {
+          delete event.anchorWeekStart;
+          return;
+        }
+        let offset = Math.floor(Number(startWeekSelect.value));
+        if (!Number.isFinite(offset) || offset < 0) offset = 0;
+        if (offset >= interval) offset = interval - 1;
+        const baseWeek = normalizeWeekStartTimestamp(now());
+        const anchor = baseWeek + offset * WEEK_MS;
+        event.anchorWeekStart = anchor;
+      };
+
       updateIntervalSuffix(intervalWeeks);
+      refreshStartWeekSelection();
+      if (!Number.isFinite(Number(event.anchorWeekStart))) {
+        commitStartWeek();
+      }
 
       const commitInterval = () => {
         let numeric = Math.floor(Number(intervalInput.value));
@@ -1485,6 +1576,8 @@
         event.intervalWeeks = numeric;
         delete event.anchorWeekStart;
         updateIntervalSuffix(numeric);
+        refreshStartWeekSelection();
+        commitStartWeek();
       };
 
       intervalInput.addEventListener("change", commitInterval);
@@ -1492,11 +1585,18 @@
       intervalInput.addEventListener("input", () => {
         const numeric = Math.floor(Number(intervalInput.value));
         updateIntervalSuffix(Number.isFinite(numeric) && numeric >= 1 ? numeric : 1);
+        refreshStartWeekSelection();
+      });
+
+      startWeekSelect.addEventListener("change", () => {
+        commitStartWeek();
+        refreshStartWeekSelection();
       });
 
       intervalContainer.appendChild(intervalInput);
       intervalContainer.appendChild(intervalSuffix);
       body.appendChild(intervalContainer);
+      body.appendChild(startWeekContainer);
     }
     row.appendChild(body);
     return row;

--- a/style.css
+++ b/style.css
@@ -73,6 +73,9 @@ dialog::backdrop{background:rgba(0,0,0,.6)}
 .shortterm-interval{display:flex; align-items:center; gap:6px; flex:0 0 auto;}
 .shortterm-interval input[type="number"]{width:72px;}
 .shortterm-interval span{font-size:.9rem; color:#3a3a42;}
+.shortterm-weekstart{display:flex; align-items:center; gap:6px; flex:0 0 auto;}
+.shortterm-weekstart span{font-size:.9rem; color:#3a3a42;}
+.shortterm-weekstart select{min-width:150px;}
 .shortterm-remove{margin-left:auto;}
 .loop-note{margin-top:8px; font-size:.85rem; color:#3a3a42; flex:1 1 100%;}
 .loop-note strong{font-weight:600;}


### PR DESCRIPTION
## Summary
- add a "Start on" selector for weekly short-term schedule events so users can pick the initial week in the rotation
- refresh scheduling metadata when weekly events change to keep the anchor in sync with UI selections
- style the new selector alongside the existing interval controls

## Testing
- no automated tests were run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_69093c96fe3c832d98d11db5f8a4f822

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Start on" dropdown selector for multi-week rotation cycles in the event editor, allowing users to choose the starting week when the interval exceeds one week.

* **Style**
  * Applied styling to the new week selection control with flex layout, spacing, and sizing constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->