### PR TITLE
Add fullscreen support for individual timers

### DIFF
--- a/script.js
+++ b/script.js
@@ -139,6 +139,73 @@
   const tplBtn = $("#tplBtn");
   const pauseAllBtn = $("#pauseAllBtn");
 
+  let fallbackFullscreenCard = null;
+
+  function activeNativeFullscreenElement(){
+    return document.fullscreenElement || document.webkitFullscreenElement || document.msFullscreenElement || null;
+  }
+
+  async function tryEnterNativeFullscreen(card){
+    if (!card) return false;
+    const request = card.requestFullscreen || card.webkitRequestFullscreen || card.msRequestFullscreen;
+    if (!request) return false;
+    try {
+      const result = request.call(card);
+      if (result && typeof result.then === "function") {
+        await result;
+      }
+      return true;
+    } catch (err) {
+      console.warn("Failed to enter fullscreen", err);
+      return false;
+    }
+  }
+
+  async function exitNativeFullscreenIfActive(){
+    const active = activeNativeFullscreenElement();
+    if (!active) return false;
+    const exit = document.exitFullscreen || document.webkitExitFullscreen || document.msExitFullscreen;
+    if (!exit) return false;
+    try {
+      const result = exit.call(document);
+      if (result && typeof result.then === "function") {
+        await result;
+      }
+      return true;
+    } catch (err) {
+      console.warn("Failed to exit fullscreen", err);
+      return false;
+    }
+  }
+
+  function deactivateFallbackFullscreen(card=null){
+    const target = card || fallbackFullscreenCard;
+    if (!target) return;
+    target.classList.remove("fullscreen-fallback");
+    if (target.dataset) delete target.dataset.fullscreenFallback;
+    if (!document.querySelector(".card.fullscreen-fallback")){
+      document.body.classList.remove("has-fullscreen-fallback");
+      if (!card || card === fallbackFullscreenCard) fallbackFullscreenCard = null;
+    }
+  }
+
+  function activateFallbackFullscreen(card){
+    if (!card) return;
+    if (fallbackFullscreenCard && fallbackFullscreenCard !== card){
+      deactivateFallbackFullscreen(fallbackFullscreenCard);
+    }
+    fallbackFullscreenCard = card;
+    card.classList.add("fullscreen-fallback");
+    if (card.dataset) card.dataset.fullscreenFallback = "1";
+    document.body.classList.add("has-fullscreen-fallback");
+  }
+
+  function handleEscapeForFallback(ev){
+    if (ev.key === "Escape") deactivateFallbackFullscreen();
+  }
+
+  document.addEventListener("keydown", handleEscapeForFallback);
+
   const settingsBtn = $("#settingsBtn");
   const settingsDialog = $("#settingsDialog");
   const settingsSignedOut = $("#settingsSignedOut");
@@ -3638,7 +3705,8 @@
     const actions = document.createElement("div");
     actions.className = "actions";
     const pauseBtn = (t.mode==="datetime" || t.mode==="smart") ? "" : `<button class="action-btn" data-act="pause" title="${t.paused?'Resume':'Pause'}">⏯︎</button>`;
-    actions.innerHTML = `${pauseBtn}<button class="action-btn" data-act="prestige" title="Prestige">★</button><button class="action-btn" data-act="tplsave" title="Save template">⇪</button><button class="action-btn" data-act="edit" title="Edit">✎</button><button class="action-btn" data-act="delete" title="Delete">🗑</button>`;
+    const fullscreenBtn = `<button class="action-btn" data-act="fullscreen" title="Fullscreen">⛶</button>`;
+    actions.innerHTML = `${pauseBtn}${fullscreenBtn}<button class="action-btn" data-act="prestige" title="Prestige">★</button><button class="action-btn" data-act="tplsave" title="Save template">⇪</button><button class="action-btn" data-act="edit" title="Edit">✎</button><button class="action-btn" data-act="delete" title="Delete">🗑</button>`;
     card.appendChild(actions);
 
     const title = document.createElement("div");
@@ -3754,6 +3822,23 @@
         if (t.paused){ t.pausedAt = Date.now(); t.leftWhenPaused = remNow; }
         else { const delta = Date.now() - (t.pausedAt||Date.now()); if (t.mode==="duration"){ t.start += delta; } else { t.targetMs += delta; } delete t.pausedAt; }
         render();
+      } else if (act==="fullscreen"){
+        ev.preventDefault();
+        const activeNative = activeNativeFullscreenElement();
+        if (card.classList.contains("fullscreen-fallback")){
+          deactivateFallbackFullscreen(card);
+          return;
+        }
+        if (activeNative && activeNative !== card){
+          await exitNativeFullscreenIfActive();
+        } else if (activeNative === card){
+          await exitNativeFullscreenIfActive();
+          return;
+        }
+        const success = await tryEnterNativeFullscreen(card);
+        if (!success){
+          activateFallbackFullscreen(card);
+        }
       } else if (act==="edit"){
         openEditor(t.id);
       } else if (act==="delete"){
@@ -3782,6 +3867,7 @@
   }
 
   function render(){
+    if (fallbackFullscreenCard) deactivateFallbackFullscreen(fallbackFullscreenCard);
     grid.innerHTML = "";
     timers.sort((a,b)=> remainingMs(a) - remainingMs(b));
 

--- a/style.css
+++ b/style.css
@@ -21,6 +21,32 @@ select, input{background:#171925; color:var(--text); border:1px solid rgba(255,2
 .pill{font-size:.75rem; padding:.2rem .45rem; border:1px solid rgba(255,255,255,.14); border-radius:999px; color:var(--muted)}
 .actions{position:absolute; top:10px; right:10px; display:flex; gap:6px; align-items:center}
 .action-btn{width:34px; height:34px; display:grid; place-items:center; border-radius:10px; background:#191b26; border:1px solid rgba(255,255,255,.14); cursor:pointer; font-size:16px; line-height:1;}
+body.has-fullscreen-fallback{overflow:hidden;}
+.card:fullscreen,
+.card:-webkit-full-screen,
+.card.fullscreen-fallback{border-radius:0; width:100vw; height:100vh; max-width:none; max-height:none; padding:min(6vh,48px); display:flex; flex-direction:column; justify-content:center; gap:18px; margin:0; align-items:center; text-align:center; box-sizing:border-box;}
+.card.fullscreen-fallback{position:fixed; inset:0; z-index:200;}
+.card:fullscreen .actions,
+.card:-webkit-full-screen .actions,
+.card.fullscreen-fallback .actions{top:24px; right:24px; gap:10px;}
+.card:fullscreen .title,
+.card:-webkit-full-screen .title,
+.card.fullscreen-fallback .title{margin-top:0; justify-content:center; font-size:clamp(1.4rem,3vw,2rem);}
+.card:fullscreen .subtitle,
+.card:-webkit-full-screen .subtitle,
+.card.fullscreen-fallback .subtitle{font-size:clamp(.95rem,2vw,1.1rem);}
+.card:fullscreen .big,
+.card:-webkit-full-screen .big,
+.card.fullscreen-fallback .big{font-size:clamp(52px,18vw,160px);}
+.card:fullscreen .canvaswrap,
+.card:-webkit-full-screen .canvaswrap,
+.card.fullscreen-fallback .canvaswrap{width:min(70vw,70vh); height:min(70vw,70vh);}
+.card:fullscreen .footer-row,
+.card:-webkit-full-screen .footer-row,
+.card.fullscreen-fallback .footer-row{flex-direction:column; align-items:center; gap:14px;}
+.card:fullscreen .loop-note,
+.card:-webkit-full-screen .loop-note,
+.card.fullscreen-fallback .loop-note{max-width:min(720px,90vw);}
 .canvaswrap{margin-left:auto;margin-right:auto; display:grid; place-items:center; width:min(72vw, 260px); height:min(72vw, 260px); margin:6px auto 8px; position:relative}
 .big{font-weight:900; font-variant-numeric:tabular-nums; letter-spacing:.5px; font-size:clamp(30px, 8vw, 46px); text-align:center; margin:8px 0 2px}
 .flip{display:inline-block; padding:.28rem .5rem; border-radius:12px; background:#10121a; border:1px solid rgba(255,255,255,.08); transition:transform .2s}


### PR DESCRIPTION
## Summary
- add a fullscreen control to timer cards with graceful fallback handling
- style timer cards when fullscreen so content is centered and enlarged for readability

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917af4d802c832db7fb6f205ad223d3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fullscreen mode for timer cards to provide an immersive viewing experience
  * New fullscreen button available on timer cards
  * Press Escape to exit fullscreen at any time
  * Optimized styling for fullscreen display across all browsers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->